### PR TITLE
[버그] webpack svg 사용 관련 빌드 에러 bug 버그 #14

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,14 @@ const nextConfig: NextConfig = {
       },
     },
   },
+
+  webpack: (config) => {
+    config.module.rules.push({
+      test: /\.svg$/,
+      use: ['@svgr/webpack'],
+    })
+    return config
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
## 🐞 버그 수정
svg 파일을 컴포넌트 형식으로 사용하기 위해 next.config.ts 파일을 설정했으나 빌드환경에서는 동작하지 않는 이슈가 있었습니다.
개발모드에서는 turbopack을, 프로덕션 모드에서는 webpack을 쓰기 때문에 svgr 관련 설정이 webpack에는 적용되지 않아 발생되는 것으로 판단되었습니다

## 🔍 해결 방법

- [x] 기존 turbopack에만 적용돼있던 @svgr/webpack 설정을 webpack에도 적용

## 🔍 테스트 방법 
```
yarn build
```
## 👀 관련 이슈 번호
close #14 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 이제 `.svg` 파일을 더욱 원활하게 사용할 수 있도록 지원이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->